### PR TITLE
added support for triplets

### DIFF
--- a/images/hmm/Dockerfile
+++ b/images/hmm/Dockerfile
@@ -1,13 +1,12 @@
-FROM debian as buildbase
-
-RUN apt-get -y update && apt-get -y install git gcc make wget
-
-RUN apt-get -y install libz-dev
-
 #
 # Build HMMER 3.1b2 with HPC enhancements from Arndt
 #
-FROM buildbase as hmm
+FROM debian:10.4 as hmm
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get -y update && apt-get -y install git gcc make wget
+
 ENV V=3.1b2
 
 RUN \
@@ -30,7 +29,9 @@ RUN \
 
 FROM scanon/imtools:20210401
 
-RUN apt-get -y install bc parallel
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get --allow-releaseinfo-change update && apt-get -y install bc parallel
 
 COPY --from=hmm /opt/omics /opt/omics/
 

--- a/images/meta/generate_objects.py
+++ b/images/meta/generate_objects.py
@@ -26,14 +26,15 @@ def gen_id(gid, git_url, start_date, end_date):
     print(md5hash)
     return 'nmdc:{}'.format(md5hash)
 
-def gen_data_objects(fpath, url, name, des, gid):
+def gen_data_objects(fpath, url, name, dotype, gid):
         md5 = get_md5(fpath)
         fmeta = os.stat(fpath)
 
         obj = {
            'id': 'nmdc:{}'.format(md5),
            'name': '{}_{}'.format(gid, name),
-           'description': '{} for {}'.format(des, gid),
+           'description': '{} for {}'.format(name, gid),
+           'data_object_type': dotype,
            'md5_checksum': md5,
            'url': url,
            'file_size_bytes': fmeta.st_size
@@ -74,10 +75,10 @@ def main():
         item_list = []
     for i in range(0, len(item_list),3):
         fn = item_list[i]
-        des = item_list[i+1]
-        name = item_list[i+2]
+        name = item_list[i+1]
+        dotype = item_list[i+2]
         url = '%s%s' % (args.url, fn.split('/')[-1])
-        obj = gen_data_objects(fn, url, name, des, args.id)
+        obj = gen_data_objects(fn, url, name, dotype, args.id)
         data_objects.append(obj)
         outs.append(obj['id'])
     if args.activityid:

--- a/images/meta/generate_objects.py
+++ b/images/meta/generate_objects.py
@@ -26,14 +26,14 @@ def gen_id(gid, git_url, start_date, end_date):
     print(md5hash)
     return 'nmdc:{}'.format(md5hash)
 
-def gen_data_objects(fpath, url, name, gid):
+def gen_data_objects(fpath, url, name, des, gid):
         md5 = get_md5(fpath)
         fmeta = os.stat(fpath)
 
         obj = {
            'id': 'nmdc:{}'.format(md5),
            'name': '{}_{}'.format(gid, name),
-           'description': '{} for {}'.format(name, gid),
+           'description': '{} for {}'.format(des, gid),
            'md5_checksum': md5,
            'url': url,
            'file_size_bytes': fmeta.st_size
@@ -72,11 +72,12 @@ def main():
         item_list = args.outputs
     else:
         item_list = []
-    for i in range(0, len(item_list), 2):
+    for i in range(0, len(item_list),3):
         fn = item_list[i]
-        name = item_list[i+1]
+        des = item_list[i+1]
+        name = item_list[i+2]
         url = '%s%s' % (args.url, fn.split('/')[-1])
-        obj = gen_data_objects(fn, url, name, args.id)
+        obj = gen_data_objects(fn, url, name, des, args.id)
         data_objects.append(obj)
         outs.append(obj['id'])
     if args.activityid:

--- a/images/meta/requirements.txt
+++ b/images/meta/requirements.txt
@@ -1,0 +1,5 @@
+chardet==4.0.0
+click==7.1.2
+rdflib==5.0.0
+rdflib-jsonld==0.5.0
+rdflib-pyld-compat==0.1.0

--- a/images/meta/rqcstats.py
+++ b/images/meta/rqcstats.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+
+import sys
+import json
+
+metadata = dict()
+with open(sys.argv[1],'r') as f:
+    for line in f:
+        if 'inputReads' in line:
+            key, value = line.rstrip().split("=")
+            metadata['input_read_count'] = int(value)
+        if 'inputBases' in line:
+            key, value = line.rstrip().split("=")
+            metadata['input_read_bases'] = int(value)
+        if 'outputReads' in line:
+            key, value = line.rstrip().split("=")
+            metadata['output_read_count'] = int(value)
+        if 'outputBases' in line:
+            key, value = line.rstrip().split("=")
+            metadata['output_read_bases'] = int(value)
+
+print(json.dumps(metadata, indent=2))


### PR DESCRIPTION
Added support in generate_objects.py to be able to take FIle | Description | Name to run code as such:

```
python generate_objects.py --type "nmdc:ReadQCAnalysisActivity" --id ${informed_by} \
             --name "Read QC Activity for ${proj}" --part ${proj} \
             --start ${start} --end $end \
             --resource '${resource}' --url ${url_root}${proj}/qa/ --giturl ${git_url} \
             --extra stats.json \
             --inputs  Ecoli_10x-int.fastq.gz \
             --outputs \
             ${qadir}/nmdc_mga0rgxp26_filtered.fastq.gz "Reads QC result fastq (clean data)" "Filtered Sequencing Read"\
             ${qadir}/nmdc_mga0rgxp26_filterStats.txt "Reads QC summary statistics" "QC Statistics" 
```