### PR TITLE
update product mapping files to a specific path

### DIFF
--- a/functional-annotation.wdl
+++ b/functional-annotation.wdl
@@ -39,7 +39,7 @@ workflow f_annotate {
 #  String  tmhmm_decode_parser="/opt/omics/bin/functional_annotation/decodeanhmm_parser.py"
   File    sa_gff
   String  product_assign_bin="/opt/omics/bin/functional_annotation/assign_product_names_and_create_fa_gff.py"
-  String  product_names_mapping_dir="${database_location}"+"/Product_Name_Mappings/latest"
+  String  product_names_mapping_dir="${database_location}"+"/Product_Name_Mappings/20230814"
   String  container
   String  hmm_container="microbiomedata/img-omics@sha256:d5f4306bf36a97d55a3710280b940b89d7d4aca76a343e75b0e250734bc82b71"
   String  last_container="microbiomedata/img-omics@sha256:d5f4306bf36a97d55a3710280b940b89d7d4aca76a343e75b0e250734bc82b71"


### PR DESCRIPTION
Update product mapping files to a specific path instead of a symlink which was a bad practice. 