### PR TITLE
Upgrade and pin third-party actions using commit hashes

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -14,14 +14,14 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout branch
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             - name: Get Version
               id: get_version
               run: |
                   VERSION=$(grep "IMG_annotation_pipeline_ver=" Dockerfile  | cut -d"=" -f 2 | head -n 1)
                   echo "version=${VERSION}" >> $GITHUB_OUTPUT
             - name: Authenticate with container registry
-              uses: docker/login-action@v3
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
@@ -33,7 +33,7 @@ jobs:
               # For more info: https://github.com/docker/build-push-action#usage.
             - name: Build and push container image
               id: push
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
               with:
                   context: .
                   file: Dockerfile

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Read version
         id: get_version

--- a/.github/workflows/test-build-and-push-image.yml
+++ b/.github/workflows/test-build-and-push-image.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout branch
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: "36-annotation-update-to-53-genomad"
             - name: Get Version
@@ -23,7 +23,7 @@ jobs:
                   VERSION=$(grep "IMG_annotation_pipeline_ver=" Dockerfile  | cut -d"=" -f 2 | head -n 1)
                   echo "version=${VERSION}" >> $GITHUB_OUTPUT
             - name: Authenticate with container registry
-              uses: docker/login-action@v3
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
@@ -35,7 +35,7 @@ jobs:
               # For more info: https://github.com/docker/build-push-action#usage.
             - name: Build and push container image
               id: push
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
               with:
                   context: .
                   file: Dockerfile

--- a/.github/workflows/wdl_linter.yml
+++ b/.github/workflows/wdl_linter.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.8' # specify the Python version you need
 


### PR DESCRIPTION
These changes implement the recommend security hardening step of [pinning third party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) using commit hashes. They also do an upgrade to avoid using [deprecated Node 20 actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

---

Implementation note: these changes were automatically generated with [pinact](https://github.com/suzuki-shunsuke/pinact):
```
pinact run --update --min-age 7
```
